### PR TITLE
Unit test with log out edit

### DIFF
--- a/js/utils/editBtn.js
+++ b/js/utils/editBtn.js
@@ -57,7 +57,7 @@ const createEditBtn = () => {
  * //Example usage
  * logOut();
  */
-const logOut = () => {
+export const logOut = () => {
   localStorage.removeItem("name", "token");
   window.location.href = `../../index.html`;
 };

--- a/js/utils/editBtn.test.js
+++ b/js/utils/editBtn.test.js
@@ -13,28 +13,7 @@
 // IF logOut had been exported from editBtn.js, this would be the test:
 // Commented out to bypass failing test :
 // ****************************************************************** //
-// import logOut from "./editBtn.js"; // THIS will not work since logOut is not exported from editBtn.js
-// import "jest-localstorage-mock";
-
-// describe("logOut", () => {
-//   it("should remove name and token from localStorage and navigate to the home page", () => {
-//     // Mock the navigateTo function
-//     const navigateTo = jest.fn();
-
-//     logOut(navigateTo);
-
-//     // Ensure localStorage.removeItem is called for "name" and "token"
-//     expect(localStorage.removeItem).toHaveBeenCalledWith("name"); // This will pass
-//     expect(localStorage.removeItem).toHaveBeenCalledWith("token"); // THIS WOULD FAIL IF localStorage.removeItem("name", "token"); WAS NOT SPLIT UP INTO TWO LINES
-
-//     // Verify that navigateTo was called with the expected URL
-//     expect(navigateTo).toHaveBeenCalledWith("../../index.html");
-//   });
-// });
-
-// Actual test to not get fail due to empty test file:
-// logOut.test.js
-import logOut from "./logOut.js";
+import { logOut } from "./editBtn.js"; // THIS will not work since logOut is not exported from editBtn.js
 import "jest-localstorage-mock";
 
 describe("logOut", () => {
@@ -45,10 +24,32 @@ describe("logOut", () => {
     logOut(navigateTo);
 
     // Ensure localStorage.removeItem is called for "name" and "token"
-    expect(localStorage.removeItem).toHaveBeenCalledWith("name");
-    expect(localStorage.removeItem).toHaveBeenCalledWith("token");
+    expect(localStorage.removeItem).toHaveBeenCalledWith("name"); // This will pass
+    expect(localStorage.removeItem).toHaveBeenCalledWith("token"); // THIS WILL FAIL IF localStorage.removeItem("name", "token"); WAS NOT SPLIT UP INTO TWO LINES in editBtn.js
 
     // Verify that navigateTo was called with the expected URL
     expect(navigateTo).toHaveBeenCalledWith("../../index.html");
   });
 });
+
+// Actual test to not get fail due to empty test file:
+// logOut.test.js
+// ******* COMMENTED OUT NOW THAT IMPORT FROM editBtn can be done after adding export in front of logOut in editBtn.js ********
+// import logOut from "./logOut.js";
+// import "jest-localstorage-mock";
+
+// describe("logOut", () => {
+//   it("should remove name and token from localStorage and navigate to the home page", () => {
+//     // Mock the navigateTo function
+//     const navigateTo = jest.fn();
+
+//     logOut(navigateTo);
+
+//     // Ensure localStorage.removeItem is called for "name" and "token"
+//     expect(localStorage.removeItem).toHaveBeenCalledWith("name");
+//     expect(localStorage.removeItem).toHaveBeenCalledWith("token");
+
+//     // Verify that navigateTo was called with the expected URL
+//     expect(navigateTo).toHaveBeenCalledWith("../../index.html");
+//   });
+// });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workflow-ca",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workflow-ca",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "ISC",
       "dependencies": {
         "bootstrap": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-ca",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Workflow Course Assignment",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Adds export infront of const logOut in editBtn.js so it can be imported into editBtn.test.js

Adds correct test to editBtn.test.js to test actual original code, and not use mockdata in logOut.js and logOut.test.js
They are still included in project, and runs on PR tho.