### PR TITLE
Workflow fix logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@
 
 ### Configurations:
 
+#### FIXES
+
+Fixed the logOut function in the original project, so that it now clears the token from local storage.
+Changed to this:
+
+```javascript
+export const logOut = () => {
+  localStorage.removeItem("name");
+  localStorage.removeItem("token");
+  window.location.href = `../../index.html`;
+};
+```
+
 ##### Issue 1.
 
 We are supposed to fork the project, but that is not possible as i have fork from the css-frameworks in my own account from when we did the css-frameworks-ca.
@@ -33,7 +46,7 @@ This did not work either.
 
 #### Jest:
 
-[![Automated Unit Testing](https://github.com/runeunhjem/workflow-ca/actions/workflows/unit-test.yml/badge.svg)](https://github.com/runeunhjem/workflow-ca/actions/workflows/unit-test.yml)
+[![Automated Unit Testing](https://github.com/runeunhjem/workflow-ca/actions/workflows/unit-test.yml/badge.svg?branch=workflow-fix-logout)](https://github.com/runeunhjem/workflow-ca/actions/workflows/unit-test.yml)
 
 Automatically test the following functionalities with unit tests:
 
@@ -42,7 +55,7 @@ Automatically test the following functionalities with unit tests:
 
 #### Cypress:
 
-[![Automated E2E Testing](https://github.com/runeunhjem/workflow-ca/actions/workflows/main.yml/badge.svg)](https://github.com/runeunhjem/workflow-ca/actions/workflows/main.yml)
+[![Automated E2E Testing](https://github.com/runeunhjem/workflow-ca/actions/workflows/main.yml/badge.svg?branch=workflow-fix-logout)](https://github.com/runeunhjem/workflow-ca/actions/workflows/main.yml)
 
 Do automated end-to-end tests on the following functionalities:
 

--- a/README.md
+++ b/README.md
@@ -52,12 +52,13 @@ Do automated end-to-end tests on the following functionalities:
 
 #### Bugs/issues added to the issues tab:
 
-1. Both Jest and Cypress logOut tests will fail due to this code in original project:
+1. Both Jest and Cypress logOut tests failed due to original code in original project, so changed to this to fix:
 
 ```javascript
 // js/utils/editBtn.js
 export const logOut = () => {
-  localStorage.removeItem("name", "token");
+  localStorage.removeItem("name");
+  localStorage.removeItem("token");
   window.location.href = `../../index.html`;
 };
 ```

--- a/js/utils/editBtn.js
+++ b/js/utils/editBtn.js
@@ -33,7 +33,12 @@ const createdEditDropDown = () => {
 const createEditBtn = () => {
   const element = createElement("div", ["dropdown"]);
 
-  const btn = createElement("button", ["btn", "text-white", "bg-primary", "border", "border-primary", "dropdown-toggle"], undefined, "Edit");
+  const btn = createElement(
+    "button",
+    ["btn", "text-white", "bg-primary", "border", "border-primary", "dropdown-toggle"],
+    undefined,
+    "Edit"
+  );
   btn.setAttribute("data-bs-toggle", "dropdown");
 
   const firstLi = createElement("li", ["dropdown-item", "text-primary"], undefined, "Log Out");
@@ -58,6 +63,7 @@ const createEditBtn = () => {
  * logOut();
  */
 export const logOut = () => {
-  localStorage.removeItem("name", "token");
+  localStorage.removeItem("name");
+  localStorage.removeItem("token");
   window.location.href = `../../index.html`;
 };

--- a/js/utils/editBtn.test.js
+++ b/js/utils/editBtn.test.js
@@ -1,35 +1,21 @@
-// Imported logOut form editBtn.js, but this was not exported in Fredrik's original code
-// Connor said to add export to the logOut function so we could test the actual function
-// and not make mock test of the logOut function.
-
-// So since the localStorage.removeItem("name", "token"); is in one line in editBtn.js, this test will fail.
-// It will only remove "name" from localStorage and not "token".
-// This is reported as a bug in editBtn.js to issues tab on GitHub.
-
 import { logOut } from "./editBtn.js";
 import "jest-localstorage-mock";
 
 describe("logOut", () => {
-  it("should remove name and token from localStorage and navigate to the home page", () => {
-    // Mock the navigateTo function
-    const navigateTo = jest.fn();
+  it('should remove the "token" from local storage', () => {
+    // Call setup to initialize the local storage mock
+    localStorage.clear();
 
-    // Mock window.location.href to avoid the "Not implemented: navigation" error
-    const originalLocation = window.location;
-    delete window.location;
-    window.location = { href: "" };
+    // Add a token to local storage
+    localStorage.setItem("token", "exampleToken");
 
-    logOut(navigateTo);
+    // Call the logOut function
+    logOut();
 
-    // Ensure localStorage.removeItem is called for "name" and "token"
-    expect(localStorage.removeItem).toHaveBeenCalledWith("name");
+    // Expect that localStorage.removeItem was called with 'token'
     expect(localStorage.removeItem).toHaveBeenCalledWith("token");
 
-    // Verify that navigateTo was called with the expected URL
-    expect(navigateTo).toHaveBeenCalledWith("../../index.html");
-
-    // Reset window.location to its original state
-    window.location = originalLocation;
+    // Expect that localStorage.getItem('token') returns null after logOut
+    expect(localStorage.getItem("token")).toBeNull();
   });
 });
-


### PR DESCRIPTION
Fixed the logOut function in the original project, so that it now clears the token from local storage. Changed to this:

export const logOut = () => {
  localStorage.removeItem("name");
  localStorage.removeItem("token");
  window.location.href = `../../index.html`;
};